### PR TITLE
Switch phpunit install via php_pear to use :install

### DIFF
--- a/recipes/pear.rb
+++ b/recipes/pear.rb
@@ -34,5 +34,5 @@ php_pear "PHPUnit" do
     if node[:phpunit][:version] != "latest"
         version "#{node[:phpunit][:version]}"
     end
-    action :upgrade if node['phpunit']['version'] == "latest"
+    action :upgrade if node[:phpunit][:version] == "latest"
 end


### PR DESCRIPTION
:upgrade action for php_pear is broken if someone is trying to set a specific version. It basically upgrades to the latest version on the first run, instead of respecting the designated version, and then all subsequent chef runs fail.

I recognize that fixing the php_pear provider would be best, but it's very convoluted and I can't quite figure it out right now in order to submit a proper PR to them.
