### PR TITLE
Update PHAR url

### DIFF
--- a/attributes/phar.rb
+++ b/attributes/phar.rb
@@ -5,5 +5,5 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-default[:phpunit][:phar_url] = "http://pear.phpunit.de/get/phpunit.phar"
+default[:phpunit][:phar_url] = "https://phar.phpunit.de/phpunit.phar"
 default[:phpunit][:install_dir] = ""


### PR DESCRIPTION
It appears that the PHAR url has changed as per: http://phpunit.de/getting-started.html
