### PR TITLE
Delete PHPunit cache directory before creating it, so Composer always…

### DIFF
--- a/recipes/composer.rb
+++ b/recipes/composer.rb
@@ -10,6 +10,14 @@ include_recipe 'composer'
 
 phpunit_dir = "#{Chef::Config[:file_cache_path]}/phpunit"
 
+# Before creating the dir, first delete the old directory where the composer files
+# are stores. This because the Chef cache can be persistent, which causes Composer
+# to not install the executable, even if "bin-dir" is set.
+directory phpunit_dir do
+    recursive true
+    action :delete
+end
+
 directory phpunit_dir do
   owner 'root'
   group 'root'
@@ -36,10 +44,10 @@ template "#{phpunit_dir}/composer.json" do
   )
 end
 
-# composer update
+# composer install
 execute 'phpunit-composer' do
   user 'root'
   cwd phpunit_dir
-  command 'composer update'
+  command 'composer install'
   action :run
 end


### PR DESCRIPTION
… installs the PHPunit binary/executable

Hi 

I'm using this cookbook in a PHP project using Vagrant. I'm using the Cachier plugin (https://github.com/fgrehm/vagrant-cachier).
Because the cookbook use composer to install the binary, and does this is the chef cache, this is persistent between multiple Vagrant machines, or when destroying and re-creating the machine. Or even when running multiple times provision (e.g. to update or downgrade phpunit) Composer simple stops with `Nothing to install or update`

To test this I created a very minimal vagrant image here: (you need the omnibus and berkshelf plugin though) https://gist.github.com/LEDfan/7a275dea5523987fd3e97a88b4e66542
If you launch the vagrant box it works and install phpunit inside `/home/vagrant/bin`. When you login with `vagrant ssh` and remove the `/home/vagrant/bin` folder and run `vagrant provision`, the binary isn't re-created. This patch should fix this.

Note that there shouldn't be a large speed impact since Composer loads everything from cache:

```
Updating dependencies (including require-dev)
 - Installing sebastian/version (1.0.6)
  Loading from cache
```

P.s. I changed `composer update` to `composer install` since this seems bast practice, however this hasn't any influence on the behaviour from above.
