### PR TITLE
Phar install_method can now install custom versions

### DIFF
--- a/attributes/phar.rb
+++ b/attributes/phar.rb
@@ -5,5 +5,5 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-default['phpunit']['phar_url'] = 'https://phar.phpunit.de/phpunit.phar'
+default['phpunit']['phar_url'] = 'https://phar.phpunit.de'
 default['phpunit']['install_dir'] = '/usr/bin'

--- a/recipes/phar.rb
+++ b/recipes/phar.rb
@@ -5,7 +5,16 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-remote_file "#{node['phpunit']['install_dir']}/phpunit" do
-  source node['phpunit']['phar_url']
-  mode 0755
+if node['phpunit']['version'] != 'latest'
+  # install custom version
+  remote_file "#{node['phpunit']['install_dir']}/phpunit" do
+    source "#{node['phpunit']['phar_url']}/phpunit-#{node['phpunit']['version']}.phar"
+    mode 0755
+  end
+else
+  # install latest version
+  remote_file "#{node['phpunit']['install_dir']}/phpunit" do
+    source "#{node['phpunit']['phar_url']}/phpunit.phar"
+    mode 0755
+  end
 end


### PR DESCRIPTION
Note: You must use the exact version ie

```
"phpunit => {
  "install_method" => "phar",
  "version" => "4.8.19"
}
```

Tested on vagrant 1.8.4 and Chef 11.15.0